### PR TITLE
Implemented Harvesting Crops

### DIFF
--- a/Assets/Prefabs/Environment/Crops/Crop.prefab
+++ b/Assets/Prefabs/Environment/Crops/Crop.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1783648435483425508}
   - component: {fileID: 7092067884670656403}
   - component: {fileID: 8270902930465381955}
+  - component: {fileID: 864715156728586944}
   m_Layer: 0
   m_Name: Crop
   m_TagString: Untagged
@@ -99,3 +100,48 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spriteRenderer: {fileID: 7092067884670656403}
   deadSprite: {fileID: 21300000, guid: f5268370d644c6f4e9b9528ec2474cc4, type: 3}
+--- !u!61 &864715156728586944
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2387287831670960067}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.375}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -4937,7 +4937,7 @@ MonoBehaviour:
   hiddenWaterTile: {fileID: 11400000, guid: c0193c5efee5a934abc61ec3b9adbde2, type: 2}
   tilledTile: {fileID: 11400000, guid: 24df2d302ae018942ab8b0b7500783c7, type: 2}
   wateredTile: {fileID: 11400000, guid: ae14ae6fa6943d94da23b4ded2e5abed, type: 2}
-  wateredTileDuration: 60
+  wateredTileDuration: 40
   cropPrefab: {fileID: 2387287831670960067, guid: 5a8991bc40552fd4a8efb50da5564678, type: 3}
 --- !u!1001 &718902881
 PrefabInstance:
@@ -14158,7 +14158,19 @@ MonoBehaviour:
     m_ActionId: 5524acff-ece3-44bb-9f2b-a81257522c7b
     m_ActionName: Player/Use[/Mouse/leftButton]
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1429586045}
+        m_TargetAssemblyTypeName: Plattko.PlayerController, Assembly-CSharp
+        m_MethodName: OnUseSecondary
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: 13eb105b-4b8c-4141-b54e-48ef3fd6acf0
     m_ActionName: Player/Interact[/Mouse/rightButton]
   - m_PersistentCalls:
@@ -14393,7 +14405,9 @@ MonoBehaviour:
   lastMoveDir: {x: 0, y: 0}
   tileSelector: {fileID: 1369406878}
   tileManager: {fileID: 715899600}
+  tileSelectBoxLayer: 6
   spriteRenderer: {fileID: 0}
+  interactDistance: 2
 --- !u!95 &1429586046
 Animator:
   serializedVersion: 5

--- a/Assets/ScriptableObjects/Items/Seeds/PotatoSeed.asset
+++ b/Assets/ScriptableObjects/Items/Seeds/PotatoSeed.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   isItemStackable: 1
   image: {fileID: -2014847206, guid: 5448c35353f3e9345be68d1f5e7fa322, type: 3}
   cropItem: {fileID: 11400000, guid: d350711cdd4a3ee46b884019a13dbb3a, type: 2}
-  timeToGrow: 120
+  timeToGrow: 60
   growProgressSprites:
   - {fileID: 659551459, guid: 086cdc8c6da58fd408f6546f5d459625, type: 3}
   - {fileID: -203810072, guid: 086cdc8c6da58fd408f6546f5d459625, type: 3}

--- a/Assets/Scripts/Crops/Crop.cs
+++ b/Assets/Scripts/Crops/Crop.cs
@@ -4,9 +4,10 @@ using UnityEngine;
 
 namespace Plattko
 {
-    public class Crop : MonoBehaviour
+    public class Crop : MonoBehaviour, IInteractable
     {
         private TileManager tileManager;
+        private InventoryManager inventoryManager;
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Sprite deadSprite;
 
@@ -20,7 +21,7 @@ namespace Plattko
         private float growthStageTimer = 0f;
         private int growthStageIndex = 0;
 
-        private float timeToDie = 180f;
+        private float timeToDie = 120f;
         private float deathTimer;
 
         private Sprite[] growthProgressSprites;
@@ -39,7 +40,8 @@ namespace Plattko
             }
         }
 
-        public void InitialiseCrop(Item crop, float timeToGrow, Sprite[] progressSprites, Sprite harvestSprite, Vector3Int tilePos, TileManager tileManager)
+        public void InitialiseCrop(Item crop, float timeToGrow, Sprite[] progressSprites, Sprite harvestSprite, 
+            Vector3Int tilePos, TileManager tileManager, InventoryManager inventoryManager)
         {
             cropItem = crop;
             this.timeToGrow = timeToGrow;
@@ -47,6 +49,7 @@ namespace Plattko
             readyToHarvestSprite = harvestSprite;
             this.tilePos = tilePos;
             this.tileManager = tileManager;
+            this.inventoryManager = inventoryManager;
 
             spriteRenderer.sprite = this.growthProgressSprites[0];
             int growthStageCount = progressSprites.Length;
@@ -97,6 +100,30 @@ namespace Plattko
                     isDead = true;
                     spriteRenderer.sprite = deadSprite;
                 }
+            }
+        }
+
+        public void Interact()
+        {
+            HarvestCrop();
+        }
+
+        public void HarvestCrop()
+        {
+            if (isReadyToHarvest)
+            {
+                tileManager.RemoveOccupied(tilePos);
+                inventoryManager.AddItem(cropItem);
+                Destroy(gameObject);
+            }
+            else if (isDead)
+            {
+                tileManager.RemoveOccupied(tilePos);
+                Destroy(gameObject);
+            }
+            else
+            {
+                Debug.Log("Crop not ready to be harvested.");
             }
         }
     }

--- a/Assets/Scripts/Interaction.meta
+++ b/Assets/Scripts/Interaction.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09dd29860b1de9141bbb73fb7a2a9d84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/Interactable.cs
+++ b/Assets/Scripts/Interaction/Interactable.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Plattko
+{
+    public interface IInteractable
+    {
+        public void Interact()
+        {
+            Debug.Log("Interacted.");
+        }
+    }
+}

--- a/Assets/Scripts/Interaction/Interactable.cs.meta
+++ b/Assets/Scripts/Interaction/Interactable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 486761e9461806c40a391a15fa92c752
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -24,7 +24,10 @@ namespace Plattko
         [Header("Tile Interaction")]
         public TileSelector tileSelector;
         public TileManager tileManager;
+        [SerializeField] private int tileSelectBoxLayer;
         [HideInInspector] public SpriteRenderer spriteRenderer;
+
+        public float interactDistance = 3f;
 
         void Start()
         {
@@ -146,6 +149,42 @@ namespace Plattko
         {
             if (context.performed)
             {
+                Vector3 mouseWorldPos;
+                mouseWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+                mouseWorldPos.z = 0f;
+
+                if ((mouseWorldPos - transform.position).sqrMagnitude < interactDistance)
+                {
+                    LayerMask layerMask = ~(1 << tileSelectBoxLayer);
+                    RaycastHit2D hit = Physics2D.Raycast(Camera.main.ScreenToWorldPoint(Input.mousePosition), Vector2.zero, Mathf.Infinity, layerMask);
+
+                    if (hit.collider != null)
+                    {
+                        Debug.Log("Collider: " + hit.collider);
+                        
+                        IInteractable interactable = hit.collider.GetComponent<IInteractable>();
+
+                        if (interactable != null)
+                        {
+                            interactable.Interact();
+                            return;
+                        }
+                        else
+                        {
+                            Debug.Log("No interactable.");
+                        }
+                    }
+                    else
+                    {
+                        Debug.Log("No collision detected");
+                    }
+                }
+                else
+                {
+                    Debug.Log("Distance: " + (Camera.main.ScreenToWorldPoint(Input.mousePosition) - transform.position).magnitude);
+                    Debug.Log("Mouse out of range for interaction.");
+                }
+
                 Item item = inventoryManager.GetSelectedItem();
                 item.UseSecondary(this);
             }

--- a/Assets/Scripts/ScriptableObjects/ItemTypes/SeedClass.cs
+++ b/Assets/Scripts/ScriptableObjects/ItemTypes/SeedClass.cs
@@ -36,10 +36,11 @@ namespace Plattko
 
         private void PlantCrop(Vector3Int tilePos, PlayerController playerController)
         {
+            TileManager tileManager = playerController.tileManager;
             Vector2 spawnPos = new Vector2(tilePos.x + spawnOffset.x, tilePos.y + spawnOffset.y);
             playerController.tileManager.SetOccupied(tilePos);
-            Crop crop = Instantiate(playerController.tileManager.cropPrefab, spawnPos, Quaternion.identity).GetComponent<Crop>();
-            crop.InitialiseCrop(cropItem, timeToGrow, growProgressSprites, readyToHarvestSprite, tilePos, playerController.tileManager);
+            Crop crop = Instantiate(tileManager.cropPrefab, spawnPos, Quaternion.identity).GetComponent<Crop>();
+            crop.InitialiseCrop(cropItem, timeToGrow, growProgressSprites, readyToHarvestSprite, tilePos, tileManager, playerController.inventoryManager);
             playerController.inventoryManager.ConsumeItem();
         }
     }


### PR DESCRIPTION
- Created IInteractable Interface with Interact method.
- Added HarvestCrop method to Crop script that adds the Crop Item to the player's Inventory and destroys the Crop if it is ready to harvest or just destroys the Crop if it is dead.
- Added IInterface to Crop script and added Interact method that calls HarvestCrop.
- Updated UseSecondary in PlayerController script to check if there is an interactable object within range of the player at the mouses position and only interact with the interactable object (not use the equipped item) if there is.
- Updated SeedClass to provide the InventoryManager when Initialising the crop in PlantCrop.
- Reduced the watered tile duration from 60 to 40 seconds.
- Reduced the Potato's time to grow from 120 to 60 seconds.
- Reduced the time for crops to die from 180 to 120 seconds.